### PR TITLE
fix readme typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ Add your mongoDB URI and Google OAuth credentials to the config.env file
 # Install dependencies
 npm install
 
-# Run in develpment
+# Run in development
 npm run dev
 
 # Run in production


### PR DESCRIPTION
Fix typo on readme from ```develpment``` to ```development```