### PR TITLE
Logout after browser close fixed

### DIFF
--- a/app.js
+++ b/app.js
@@ -74,6 +74,9 @@ app.use(
     resave: false,
     saveUninitialized: false,
     store: new MongoStore({ mongooseConnection: mongoose.connection }),
+    cookie: {
+          maxAge: 60 * 60 * 24 * 90 * 1000,
+      },
   })
 )
 


### PR DESCRIPTION
### The Default age of the cookies of express session is _`session`_ .  So , here setting max age to 3 months. Which , prevent user from logout after browser close.