### PR TITLE
Fix req.logout() - new version of Passport

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -18,9 +18,11 @@ router.get(
 
 // @desc    Logout user
 // @route   /auth/logout
-router.get('/logout', (req, res) => {
-  req.logout()
-  res.redirect('/')
+router.get('/logout', (req, res, next) => {
+  req.logout((error) => {
+      if (error) {return next(error)}
+      res.redirect('/')
+  })
 })
 
 module.exports = router


### PR DESCRIPTION
Fixed issue#46 
Since version 0.6.0 req.logout is asynchronous. req.logout() requires a callback function
This is part of a larger change that averts session fixation attacks.